### PR TITLE
Fix public key printing after a gpg key is generated

### DIFF
--- a/go/gpg/main.go
+++ b/go/gpg/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/google/go-github/v54/github"
 	"golang.org/x/crypto/nacl/box"
@@ -102,14 +103,20 @@ func main() {
 		log.Fatalf("Error uploading GPG key to GitHub: %v", err)
 	}
 
-	var pb bytes.Buffer
-	if err = es.Serialize(&pb); err != nil {
-		log.Fatalf("Error serializing public key: %v", err)
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		log.Fatalf("Error calling armor encode: %v", err)
 	}
 
+	if err = es.Serialize(w); err != nil {
+		log.Fatalf("Error serializing public key: %v", err)
+	}
+	w.Close()
+
 	fmt.Println("")
-	fmt.Println("PUBLIC KEY BASE64:")
-	fmt.Println(base64.StdEncoding.EncodeToString(pb.Bytes()))
+	fmt.Println("PUBLIC KEY:")
+	fmt.Println(buf.String())
 }
 
 func setSecret(ctx context.Context, privKey []byte) error {


### PR DESCRIPTION
This now properly prints the key:
```sh
➜  gpg git:(gpg-action-add-env) ✗ go run main.go --org tomasmik-testorg --repo testing-signatures
Generating GPG key...
Setting secret in tomasmik-testorg/testing-signatures...

PUBLIC KEY:
-----BEGIN PGP PUBLIC KEY BLOCK-----

xsFNBGVUxiYBEADGm/I86iMwrAG/3dtUEVAVFqcK9LB59SDsOsvw6CzTX64fgMhr
w7y8/rdokgudBdMRBsbr9acrmuldIds9eAMkUB6KMVTbZNJaH6hINTx67RaB3VSZ
Wes4n24EP/7huIrfXEikvs0iRxAAmUXVh6elwuhYb+vBKmKYri0W8zwczfbYM4oO
BUKdAAVK0f1pCfnl9idqT/Ya2MzkfbczFUbI1r26mlO2ir5zmTm3JHYcT3/Gu9dK
....
```