### PR TITLE
Update fork syncing to force tag pushes

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Push tags to origin
         run: |
-          git push --tags origin
+          git push --tags origin --force
 
       - name: Check Tags for Releases
         run: |


### PR DESCRIPTION
This is to help us handle issues where tags are moved but that breaks our sync script