### PR TITLE
Fixes opentofu/registry#686: No provider releases for FreeBSD and others

### DIFF
--- a/goreleaser_v1.yaml
+++ b/goreleaser_v1.yaml
@@ -13,8 +13,26 @@ builds:
       - "386"
       - amd64
     ignore:
-      - goarch: "386"
-        goos: darwin
+      - goos: freebsd
+        goarch: arm64
+      - goos: openbsd
+        goarch: arm
+      - goos: openbsd
+        goarch: arm64
+      - goos: solaris
+        goarch: "386"
+      - goos: solaris
+        goarch: arm
+      - goos: solaris
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
     ldflags:
       - -s -w -X main.Version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"

--- a/goreleaser_v1.yaml
+++ b/goreleaser_v1.yaml
@@ -3,9 +3,9 @@ builds:
       - CGO_ENABLED=0
     flags: []
     goos:
+      - darwin
       - linux
       - windows
-      - darwin
       - freebsd
       - openbsd
       - solaris
@@ -13,6 +13,10 @@ builds:
       - "386"
       - amd64
     ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
       - goos: freebsd
         goarch: arm64
       - goos: openbsd
@@ -25,14 +29,6 @@ builds:
         goarch: arm
       - goos: solaris
         goarch: arm64
-      - goos: windows
-        goarch: arm
-      - goos: windows
-        goarch: arm64
-      - goos: darwin
-        goarch: "386"
-      - goos: darwin
-        goarch: arm
     ldflags:
       - -s -w -X main.Version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"

--- a/goreleaser_v1.yaml
+++ b/goreleaser_v1.yaml
@@ -3,9 +3,12 @@ builds:
       - CGO_ENABLED=0
     flags: []
     goos:
-      - darwin
       - linux
       - windows
+      - darwin
+      - freebsd
+      - openbsd
+      - solaris
     goarch:
       - "386"
       - amd64

--- a/goreleaser_v2.yaml
+++ b/goreleaser_v2.yaml
@@ -4,9 +4,12 @@ builds:
     flags:
       - -mod=readonly
     goos:
-      - darwin
       - linux
       - windows
+      - darwin
+      - freebsd
+      - openbsd
+      - solaris
     goarch:
       - "386"
       - amd64

--- a/goreleaser_v2.yaml
+++ b/goreleaser_v2.yaml
@@ -14,8 +14,26 @@ builds:
       - "386"
       - amd64
     ignore:
-      - goarch: "386"
-        goos: darwin
+      - goos: freebsd
+        goarch: arm64
+      - goos: openbsd
+        goarch: arm
+      - goos: openbsd
+        goarch: arm64
+      - goos: solaris
+        goarch: "386"
+      - goos: solaris
+        goarch: arm
+      - goos: solaris
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
     ldflags:
       - -s -w -X main.Version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"

--- a/goreleaser_v2.yaml
+++ b/goreleaser_v2.yaml
@@ -4,9 +4,9 @@ builds:
     flags:
       - -mod=readonly
     goos:
+      - darwin
       - linux
       - windows
-      - darwin
       - freebsd
       - openbsd
       - solaris
@@ -14,6 +14,10 @@ builds:
       - "386"
       - amd64
     ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
       - goos: freebsd
         goarch: arm64
       - goos: openbsd
@@ -26,14 +30,6 @@ builds:
         goarch: arm
       - goos: solaris
         goarch: arm64
-      - goos: windows
-        goarch: arm
-      - goos: windows
-        goarch: arm64
-      - goos: darwin
-        goarch: "386"
-      - goos: darwin
-        goarch: arm
     ldflags:
       - -s -w -X main.Version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"

--- a/goreleaser_v3.yaml
+++ b/goreleaser_v3.yaml
@@ -4,9 +4,9 @@ builds:
     flags:
       - -mod=readonly
     goos:
+      - darwin
       - linux
       - windows
-      - darwin
       - freebsd
       - openbsd
       - solaris
@@ -16,6 +16,10 @@ builds:
       - arm
       - arm64
     ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
       - goos: freebsd
         goarch: arm64
       - goos: openbsd
@@ -28,14 +32,6 @@ builds:
         goarch: arm
       - goos: solaris
         goarch: arm64
-      - goos: windows
-        goarch: arm
-      - goos: windows
-        goarch: arm64
-      - goos: darwin
-        goarch: "386"
-      - goos: darwin
-        goarch: arm
     ldflags:
       - -s -w -X main.Version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"

--- a/goreleaser_v3.yaml
+++ b/goreleaser_v3.yaml
@@ -4,9 +4,12 @@ builds:
     flags:
       - -mod=readonly
     goos:
-      - darwin
       - linux
       - windows
+      - darwin
+      - freebsd
+      - openbsd
+      - solaris
     goarch:
       - "386"
       - amd64

--- a/goreleaser_v3.yaml
+++ b/goreleaser_v3.yaml
@@ -16,10 +16,26 @@ builds:
       - arm
       - arm64
     ignore:
-      - goarch: "386"
-        goos: darwin
-      - goarch: arm
-        goos: darwin
+      - goos: freebsd
+        goarch: arm64
+      - goos: openbsd
+        goarch: arm
+      - goos: openbsd
+        goarch: arm64
+      - goos: solaris
+        goarch: "386"
+      - goos: solaris
+        goarch: arm
+      - goos: solaris
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
     ldflags:
       - -s -w -X main.Version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"


### PR DESCRIPTION
This PR (hopefully) fixes opentofu/registry#686 by syncing the goreleaser files with the main OpenTofu repository.