### PR TITLE
scripts/sync: match the whole version when looking for releases

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -62,7 +62,7 @@ jobs:
 
           for tag in $tags; do
             if [[ $tag =~ ^v[0-9]+ ]]; then
-              if ! grep -q "$tag" <<< "$releases"; then
+              if ! grep -q -x "$tag" <<< "$releases"; then
                 echo "No release found for tag, will attempt to release: $tag"
                 gh workflow run artifact-release.yml -f tag="$tag" -R $GITHUB_REPOSITORY
               else


### PR DESCRIPTION
Matching a whole line should resolve an issue when a previous, pre-released alpha version causes the stable release to not kick off an artifact release workflow.