### PR TITLE
Tweak sync job to match tags exactly

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -58,11 +58,11 @@ jobs:
       - name: Check Tags for Releases
         run: |
           tags=$(git ls-remote --tags --refs | cut -f2 | sed 's/refs\/tags\///')
-          releases=$(gh release list --exclude-drafts --limit 1000 -R $GITHUB_REPOSITORY)
+          releases=$(gh release list --exclude-drafts --json tagName --limit 1000 -R $GITHUB_REPOSITORY --jq '.[].tagName')
 
           for tag in $tags; do
             if [[ $tag =~ ^v[0-9]+ ]]; then
-              if ! grep -q "$tag" <<< "$releases"; then
+              if ! grep -q "^$tag$" <<< "$releases"; then
                 echo "No release found for tag, will attempt to release: $tag"
                 gh workflow run artifact-release.yml -f tag="$tag" -R $GITHUB_REPOSITORY
               else


### PR DESCRIPTION
This fixes an issue where 2.5.3 was not picked up after 2.5.3-alpha1 was released in the hc local provider

Ran the job from a shell script manually and got:
```
From https://github.com/opentofu/terraform-provider-local
Release found for tag: v0.1.0
Release found for tag: v1.0.0
Release found for tag: v1.1.0
Release found for tag: v1.2.0
Release found for tag: v1.2.1
Release found for tag: v1.2.2
Release found for tag: v1.3.0
Release found for tag: v1.4.0
Release found for tag: v2.0.0
Release found for tag: v2.1.0
Release found for tag: v2.2.0
Release found for tag: v2.2.1
Release found for tag: v2.2.2
Release found for tag: v2.2.3
Release found for tag: v2.3.0
Release found for tag: v2.4.0
Release found for tag: v2.4.1
Release found for tag: v2.5.0
Release found for tag: v2.5.1
Release found for tag: v2.5.2
No release found for tag, will attempt to release: v2.5.3
✓ Created workflow_dispatch event for artifact-release.yml at main

To see runs for this workflow, try: gh run list --workflow=artifact-release.yml
```