### PR TITLE
Update ignore list for latest boundary release

### DIFF
--- a/dist_ignore
+++ b/dist_ignore
@@ -1,3 +1,4 @@
+terraform-provider-boundary_v1.4.0_windows_arm64
 terraform-provider-boundary_v1.3.20_windows_arm
 terraform-provider-boundary_v1.3.20_windows_arm64
 terraform-provider-boundary_v1.3.19_windows_arm


### PR DESCRIPTION
See: https://github.com/opentofu/terraform-provider-boundary/actions/runs/18032316275/job/51311341736

It looks like the windows_arm build is passing, just not windows_arm64